### PR TITLE
perf: replace static with const for global constants

### DIFF
--- a/src/core/config/world.rs
+++ b/src/core/config/world.rs
@@ -10,7 +10,7 @@ use crate::{error::Result, utils::instance::InstanceContainer};
 
 use self::world_list::WorldList;
 
-static INSTANCE_CONTAINER: Lazy<InstanceContainer<WorldList>> =
+const INSTANCE_CONTAINER: Lazy<InstanceContainer<WorldList>> =
     Lazy::new(|| InstanceContainer::new(WorldList::new()));
 
 pub async fn init_world_list(world_list_path: &Path) -> Result<()> {

--- a/src/core/config/world/local_repo.rs
+++ b/src/core/config/world/local_repo.rs
@@ -2,7 +2,7 @@ use crate::error::{GetterError, Result};
 use std::fs;
 use std::path::PathBuf;
 
-static LOCAL_REPO_DIR: &str = "local_repo";
+const LOCAL_REPO_DIR: &str = "local_repo";
 
 pub struct LocalRepo {
     path: PathBuf,

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -117,7 +117,7 @@ pub async fn https_head(
 }
 
 // Global https provider with lazy initialization
-static PROVIDER: Lazy<std::sync::Arc<rustls::crypto::CryptoProvider>> =
+const PROVIDER: Lazy<std::sync::Arc<rustls::crypto::CryptoProvider>> =
     Lazy::new(|| std::sync::Arc::new(rustls::crypto::ring::default_provider()));
 
 // Https config error wrapper error

--- a/src/utils/versioning.rs
+++ b/src/utils/versioning.rs
@@ -5,10 +5,10 @@ use version_compare;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-static VERSION_NUMBER_STRICT_MATCH_REGEX: Lazy<Regex> =
+const VERSION_NUMBER_STRICT_MATCH_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d+(\.\d+)+([.|\-|+|_| ]*[A-Za-z0-9]+)*").unwrap());
 
-static VERSION_NUMBER_MATCH_REGEX: Lazy<Regex> =
+const VERSION_NUMBER_MATCH_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d+(\.\d+)*([.|\-|+|_| ]*[A-Za-z0-9]+)*").unwrap());
 
 #[derive(Debug, Clone)]

--- a/src/websdk/repo/provider/fdroid.rs
+++ b/src/websdk/repo/provider/fdroid.rs
@@ -10,7 +10,7 @@ use crate::utils::http::{get, head, http_status_is_ok};
 use super::super::data::release::*;
 use super::base_provider::*;
 
-static FDROID_URL: &str = "https://f-droid.org";
+const FDROID_URL: &str = "https://f-droid.org";
 
 pub struct FDroidProvider;
 

--- a/src/websdk/repo/provider/github.rs
+++ b/src/websdk/repo/provider/github.rs
@@ -11,11 +11,11 @@ use crate::utils::{
     versioning::Version,
 };
 
-static GITHUB_API_URL: &str = "https://api.github.com";
-static GITHUB_URL: &str = "https://github.com";
+const GITHUB_API_URL: &str = "https://api.github.com";
+const GITHUB_URL: &str = "https://github.com";
 
-static VERSION_NUMBER_KEY: &str = "version_number_key";
-static VERSION_CODE_KEY: &str = "version_code_key";
+const VERSION_NUMBER_KEY: &str = "version_number_key";
+const VERSION_CODE_KEY: &str = "version_code_key";
 
 pub struct GitHubProvider;
 

--- a/src/websdk/repo/provider/gitlab.rs
+++ b/src/websdk/repo/provider/gitlab.rs
@@ -11,10 +11,10 @@ use crate::utils::{
     versioning::Version,
 };
 
-static GITLAB_URL: &str = "https://gitlab.com";
-static GITLAB_API_URL: &str = "https://gitlab.com/api/v4/projects";
+const GITLAB_URL: &str = "https://gitlab.com";
+const GITLAB_API_URL: &str = "https://gitlab.com/api/v4/projects";
 
-static VERSION_NUMBER_KEY: &str = "version_number_key";
+const VERSION_NUMBER_KEY: &str = "version_number_key";
 
 pub struct GitLabProvider;
 

--- a/src/websdk/repo/provider/lsposed_repo.rs
+++ b/src/websdk/repo/provider/lsposed_repo.rs
@@ -10,7 +10,7 @@ use crate::utils::versioning::Version;
 use super::super::data::release::*;
 use super::base_provider::*;
 
-static LSPOSED_REPO_API_URL: &str = "https://modules.lsposed.org/modules.json";
+const LSPOSED_REPO_API_URL: &str = "https://modules.lsposed.org/modules.json";
 
 pub struct LsposedRepoProvider;
 


### PR DESCRIPTION
- Like `constexpr` in C++ / C23, `const` variables in Rust are evaluated during compilation, which is more efficient than `static`.