### PR TITLE
refactor: partially revert #23

### DIFF
--- a/src/core/config/world.rs
+++ b/src/core/config/world.rs
@@ -10,7 +10,7 @@ use crate::{error::Result, utils::instance::InstanceContainer};
 
 use self::world_list::WorldList;
 
-const INSTANCE_CONTAINER: Lazy<InstanceContainer<WorldList>> =
+static INSTANCE_CONTAINER: Lazy<InstanceContainer<WorldList>> =
     Lazy::new(|| InstanceContainer::new(WorldList::new()));
 
 pub async fn init_world_list(world_list_path: &Path) -> Result<()> {

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -117,7 +117,7 @@ pub async fn https_head(
 }
 
 // Global https provider with lazy initialization
-const PROVIDER: Lazy<std::sync::Arc<rustls::crypto::CryptoProvider>> =
+static PROVIDER: Lazy<std::sync::Arc<rustls::crypto::CryptoProvider>> =
     Lazy::new(|| std::sync::Arc::new(rustls::crypto::ring::default_provider()));
 
 // Https config error wrapper error

--- a/src/utils/versioning.rs
+++ b/src/utils/versioning.rs
@@ -5,10 +5,10 @@ use version_compare;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-const VERSION_NUMBER_STRICT_MATCH_REGEX: Lazy<Regex> =
+static VERSION_NUMBER_STRICT_MATCH_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d+(\.\d+)+([.|\-|+|_| ]*[A-Za-z0-9]+)*").unwrap());
 
-const VERSION_NUMBER_MATCH_REGEX: Lazy<Regex> =
+static VERSION_NUMBER_MATCH_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d+(\.\d+)*([.|\-|+|_| ]*[A-Za-z0-9]+)*").unwrap());
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
- According to [The Rust Reference](https://doc.rust-lang.org/reference/items/static-items.html), when interior mutability is required, prefer `static` over `const`.

> Constants should, in general, be preferred over statics unless one of the following are true:
    Large amounts of data are being stored
    The single-address property of statics is required.
    Interior mutability is required.
